### PR TITLE
Initial plugin version

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,98 @@
+name: Testing
+on: [push]
+jobs:
+  Test-Downloader-Plugin:
+    runs-on: ubuntu-latest
+    container: alpine/helm:3.5.4
+    env:
+      HELM_BIN: helm
+      HELM_PLUGIN_DIR: .
+      TEST_SCRIPT: |-
+        result="$(bin/discover . . . "${path}")"
+        test "$expected" == "$result" \
+        || (echo "Expected:
+        ${expected}
+        Result:
+        ${result}"; return 1)
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v2
+      - name: Establish test config hierarchy
+        run: |
+          mkdir -p test/dir.yaml
+          mkdir -p test/one/dir.txt
+
+          echo a: 1 > test/foo.yaml
+          echo b: 2 > test/bar.yml
+          echo c: 3 > test/baz.txt
+          echo d: 4 > test/one/foo.yaml
+          echo e: 5 > test/one/dir.txt/foo.yaml
+          echo f: 6 > test/one/fizz.txt
+          echo g: 7 > test/dir.yaml/foo.enc
+
+      - name: Test default behaviour
+        env:
+          path: discover://test
+          expected: |-
+            a: 1
+            b: 2
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test recursive behaviour
+        env:
+          path: discover://test?recursive
+          expected: |-
+            a: 1
+            b: 2
+            d: 4
+            e: 5
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test suffix behaviour
+        env:
+          path: discover://test?suffix=.txt
+          expected: |-
+            c: 3
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test recursive and suffix behaviour
+        env:
+          path: discover://test?recursive&suffix=.txt
+          expected: |-
+            c: 3
+            f: 6
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test prefix and suffix behaviour
+        env:
+          path: discover://test?suffix=.txt&prefix=b
+          expected: |-
+            c: 3
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test unioned prefix and suffix behaviour
+        env:
+          path: discover://test?suffix=.txt&prefix=b&union
+          expected: |-
+            b: 2
+            c: 3
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test recursive prefix and suffix behaviour
+        env:
+          path: discover://test?suffix=.txt&prefix=f&recursive
+          expected: |-
+            f: 6
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test recursive unioned prefix and suffix behaviour
+        env:
+          path: discover://test?union&suffix=.txt&prefix=f&recursive
+          expected: |-
+            a: 1
+            c: 3
+            d: 4
+            e: 5
+            f: 6
+            g: 7
+        run: sh -c "${TEST_SCRIPT}"

--- a/README.md
+++ b/README.md
@@ -1,2 +1,112 @@
 # helm-discover
 A Helm downloader plugin that supports discovery of values files.
+
+This plugin provides only a "downloader" protocol.  Despite the name,
+this protocol is used to discover/collect all values files in a given
+_local_ directory.
+
+Various options are available to refine which files are selected, and
+whether to recurse into subdirecories.
+
+![Plugin Tests](https://github.com/scalen/helm-discover/actions/workflows/test.yml/badge.svg)
+
+## Installation
+
+After installing Helm, simply run the following:
+```bash
+helm plugin install https://github.com/scalen/helm-discover
+```
+
+## Usage
+
+This is only applicable to the `-f` or `--values` option of a Helm
+command (e.g. `install`, `upgrade` or `template`).  The basic usage
+is to reference a directory from which to collect all non-hidden files
+with the extension `.yaml` or `.yml`, not including sub-directories:
+
+```bash
+helm upgrade -f discover://path/to/values path/to/chart
+```
+
+## Options
+
+Options may be used to change which files are discovered.  These are
+specified in the format of URL query parameters. For example, in order
+to collect all files that start `0_` or `1_` and end `.yml` from the given
+directory and all subdirectories:
+
+```bash
+... -f discover://path/to/values?recursive&prefix=0_&prefix=1_&suffix=.yml
+```
+
+The available options are:
+
+`recursive`: Discover files from subdirectories recursively.
+
+`hidden`: Discover hidden files in addition to non-hidden files.
+
+`hidden-only`: Discover hidden files, and do not discover non-hidden files.
+
+`suffix=<suffix>`: Select only files named with the given suffix.  Can be
+specified multiple times, in which case files named with any of the given
+suffixes will be selected.
+
+`prefix=<prefix>`: Like `suffix=`, but for files named with the given
+prefix(es).
+
+`suffix_protocol=<suffix>/<protocol>`: Like `suffix=`, in that it selects
+files named with the given suffix(es); In addition, it uses the given
+protocol to process these specific files.  This effectively expands the
+file names as follows:
+```
+path/to/values/filename<suffix> -> <protocol>://path/to/values/filename<suffix>
+```
+This is mostly to facilitate interactions with other plugins.  For
+example, in order to discover values files with the suffix `.enc` that
+have been encrypted with
+[`helm-secrets`](https://github.com/jkroepke/helm-secrets), use the
+following query parameter:
+```
+...?suffix_protocol=.enc/secrets
+```
+
+`prefix_protocol=<prefix>/<protocol>`: Like `suffix_protocol=`, but for files named with the given prefix(es).
+
+`union`: Discovers all files with any of the given suffixes _or_ the given
+prefixes.
+
+### Usecase: Encrypted values
+
+Imagine a case where we have an arbitrary organisation of values files
+nested in a `config` directory, describing the configuration for an
+application. _Some_ of these values files at the top level contain
+sensitive information and/or configuration that may only be set by
+developers with certain clearance; this restricted information is
+encrypted-at-rest with SOPS, and identified with filename extension
+`.enc`. The remainder of the configuration is not encrypted, and those
+files use the standard YAML extensions (`.yml` and `.yaml`).
+
+Our requirements here are that:
+* Encrypted files are decrypted on the fly during `helm upgrade`/`helm
+  install`.  Assuming the Helm-secrets plugin is installed (and that the
+  deployer has access to the relevant decryption keys), this can be
+  achieved with the downloader plugin `secrets://`.
+* The values in encrypted files should always override values in
+  unencrypted files, to prevent injection of malicious configuration by
+  those without the necessary clearance.
+* All values files are otherwise expected to be orthogonal, regardless of
+  how they are nested.
+
+This can be achieved by performing two rounds of discovery, as
+demonstrated in the below `helm upgrade` command:
+```bash
+helm upgrade -f discover://config?recursive -f discover://config?suffix_protocol=.enc/secrets repo/chart
+```
+This will:
+1. Discover all non-hidden files with the extension `.yaml` or `.yml` (the
+   default behaviour) in all nested directories (`recursive` argument)
+   under `config`.
+2. Discover all non-hidden files with the extension `.enc` and decrypt them
+  (`suffix_protocol=` argument) in the root (default behaviour) of
+  `config`, overriding any duplicate config from the values established
+  by 1.

--- a/bin/discover
+++ b/bin/discover
@@ -1,0 +1,149 @@
+#!/usr/bin/env sh
+
+set -euo pipefail
+
+# HELPERS
+
+function validate_filename_part {
+  test -z "$1" || ( echo $1 | grep "[\`$'"'"'"]" ) && return 1 || return 0
+}
+
+# SET DEFAULTS
+
+find_name_prefixes=
+find_name_suffixes=
+values_files_sed_command=
+# Discard hidden files by default.
+hidden=no
+# Select only files with a valid yaml extension by default
+default_find_name_suffixes="-name '*.yaml' -o -name '*.yml'"
+# By default, only select files that are direct children (not descendants) of the diven root.
+# All descendents may be discovered using the query argument "recursive".
+find_maxdepth_arg='-maxdepth 1'
+# Intersect suffix and prefix filters by default.
+find_pref_suff_joiner=
+
+# PARSE INPUT
+
+# $4 should be of the form:
+# discover://relative/path
+# discover://relative/path?depth=2
+# discover://relative/path?suffix_protocol=.suf/proto
+# discover://relative/path?suffix_protocol=.suf/proto&suffix_protocol=.foo/bar
+# discover://relative/path?depth=3&suffix_protocol=.suf/proto
+definition=$(echo "$4" | sed 's,^.*://,,')
+
+root=$(echo "$definition" | sed 's,?.*$,,')
+query=$(echo "$definition" | sed 's,^.*?,,')
+
+# Process each query argument
+while \
+  test -n "${query}" \
+  && arg="$(echo ${query} | sed 's,&.*$,,')" \
+  && query="$(echo ${query} | sed -n 's,^[^&]*&,,p')"
+do
+  case ${arg} in
+    recursive)
+      find_maxdepth_arg=
+      ;;
+    union)
+      find_pref_suff_joiner=' -o '
+      ;;
+    hidden-only)
+      # Discard non-hidden files
+      hidden=only
+      ;;
+    hidden)
+      hidden=yes
+      ;;
+    suffix=*)
+      _suffix=$(echo ${arg} | sed 's,suffix=,,')
+      if validate_filename_part "${_suffix}" > /dev/null; then
+        # Explicitly select files with the given suffix.
+        if [ -n "${find_name_suffixes}" ]; then
+          find_name_suffixes="${find_name_suffixes} -o "
+        fi
+        find_name_suffixes="${find_name_suffixes}-name '*${_suffix}'"
+      fi
+      ;;
+    prefix=*)
+      _prefix=$(echo ${arg} | sed 's,prefix=,,')
+      if validate_filename_part "${_prefix}" > /dev/null; then
+        # Explicitly select files with the given prefix.
+        if [ -n "${find_name_prefixes}" ]; then
+          find_name_prefixes="${find_name_prefixes} -o "
+        fi
+        find_name_prefixes="${find_name_prefixes}-name '${_prefix}*'"
+      fi
+      ;;
+    suffix_protocol=*)
+      _suffix=$(echo ${arg} | sed 's,suffix_protocol=,,;s,/.*$,,')
+      _protocol=$(echo ${arg} | sed -n 's,^.*/\(..*\)$,\1://,p')
+      if validate_filename_part "${_suffix}" > /dev/null; then
+        # Explicitly select files with the given suffix.
+        if [ -n "${find_name_suffixes}" ]; then
+          find_name_suffixes="${find_name_suffixes} -o "
+        fi
+        find_name_suffixes="${find_name_suffixes}-name '*${_suffix}'"
+        # "Download" files with the given protocol (if one was provided).
+        values_files_sed_command="${values_files_sed_command};s,^\(.*${_suffix}\)$,${_protocol}\1,"
+      fi
+      ;;
+    prefix_protocol=*)
+      _prefix=$(echo ${arg} | sed 's,prefix_protocol=,,;s,/.*$,,')
+      _protocol=$(echo ${arg} | sed -n 's,^.*/\(..*\)$,\1://,p')
+      if validate_filename_part "${_prefix}" > /dev/null; then
+        # Explicitly select files with the given prefix.
+        if [ -n "${find_name_prefixes}" ]; then
+          find_name_prefixes="${find_name_prefixes} -o "
+        fi
+        find_name_prefixes="${find_name_prefixes}-name '${_prefix}*'"
+        # "Download" files with the given protocol (if one was provided).
+        values_files_sed_command="${values_files_sed_command};s,^\(.*/${_prefix}[^/]*\)$,${_protocol}\1,"
+      fi
+      ;;
+    *)
+      ;;
+  esac
+done
+
+# CONSTRUCT FILE FILTERS/FORMATTERS
+
+# Construct find query
+if [ -z "${find_name_suffixes}" ]; then
+  find_name_suffixes=${default_find_name_suffixes}
+fi
+if [ -n "${find_name_prefixes}" ]; then
+  find_query="\( \( ${find_name_prefixes} \) ${find_pref_suff_joiner} \( ${find_name_suffixes} \) \)"
+else
+  find_query="\( ${find_name_suffixes} \)"
+fi
+
+if [ "${hidden}" == "no" ]; then
+  find_query="! -name '.*' ${find_query}"
+elif [ "$hidden" == "only" ]; then
+  find_query="-name '.*' ${find_query}"
+fi
+
+# DISCOVER VALUES FILES
+
+# Selects files as requested, then puts them in a comma-separated list,
+# for provisioning to:
+# helm template -f
+values_files=$(
+  eval find "${root}" ${find_maxdepth_arg} -type f ${find_query} \
+    | sed "$values_files_sed_command" \
+    | tr '\n' , | sed 's/,$//'
+)
+
+# GENERATE VALUES
+
+if [ -z "${values_files}" ]; then
+  # If there are no values files selected, exit cleanly with no output.
+  exit 0
+fi
+$HELM_BIN template \
+    -f "${values_files}" \
+    ${HELM_PLUGIN_DIR}/charts/merged-values \
+  | grep -v '^-*$' \
+  | grep -v '^#'

--- a/charts/merged-values/Chart.yaml
+++ b/charts/merged-values/Chart.yaml
@@ -1,0 +1,5 @@
+apiVersion: v2
+name: merged-values
+description: A Helm chart for merging Helm chart values
+type: application
+version: 0.1.0

--- a/charts/merged-values/templates/values.yaml
+++ b/charts/merged-values/templates/values.yaml
@@ -1,0 +1,1 @@
+{{- toYaml .Values -}}

--- a/plugin.yaml
+++ b/plugin.yaml
@@ -1,0 +1,10 @@
+name: "discover"
+version: "0.1.0"
+usage: "-f discover://relative/path/to/values"
+description: "Include all .yaml files at a location relative to the chart root as values."
+ignoreFlags: false
+downloaders:
+- command: "bin/discover"
+  protocols:
+  - "discover"
+  - "collect"


### PR DESCRIPTION
Defaults:
* Do not search sub-directories.
* Exclude hidden files (unix style with `.` prefix).
* Filter to files with `.yaml` or `.yml` extensions.

Options:
* Search all subdirectories recursively.
* Include hidden files.
* _Only_ include hidden files.
* Filter to files with one of a set of suffixes _and_ one of a set of
  prefixes.
* Filter to files with one of a set of suffixes _or_ one of a set of
  prefixes.
* Apply downloader plugins to discovered files based on prefixes or
  suffixes.