### PR TITLE
Allow disabling default suffixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -40,6 +40,15 @@ jobs:
             b: 2
         run: sh -c "${TEST_SCRIPT}"
 
+      - name: Test behaviour without default suffix filtering
+        env:
+          path: discover://test?suffix=
+          expected: |-
+            a: 1
+            b: 2
+            c: 3
+        run: sh -c "${TEST_SCRIPT}"
+
       - name: Test recursive behaviour
         env:
           path: discover://test?recursive
@@ -171,6 +180,15 @@ jobs:
           expected: >-
             template
             -f test://test/bar.yml
+            ./charts/merged-values
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test single prefix-based protocol without default suffix filtering behaviour
+        env:
+          path: discover://test?suffix=&prefix_protocol=b/test
+          expected: >-
+            template
+            -f test://test/bar.yml,test://test/baz.txt
             ./charts/merged-values
         run: sh -c "${TEST_SCRIPT}"
 

--- a/README.md
+++ b/README.md
@@ -75,6 +75,23 @@ following query parameter:
 `union`: Discovers all files with any of the given suffixes _or_ the given
 prefixes.
 
+### Default suffixes
+
+It is important to note that the following suffix options are applied by
+default:
+```
+suffix=.yml&suffix=.yaml
+```
+This will apply regardless of the `prefix=...` or `prefix_protocol=.../...`
+options specified.  This can lead to some unexpected behaviour where
+values files are unexpectedly excluded (or included, when using the
+`union` option).
+
+However, these default suffix options will be removed if any other
+`suffix=...` and/or `suffix_protocol=.../...` options are specified.  As
+such, if you wish to disable suffix filtering entirely, the null-suffix
+option `suffix=` (e.g. `...?suffix=&...`) may be used.
+
 ### Usecase: Encrypted values
 
 Imagine a case where we have an arbitrary organisation of values files

--- a/bin/discover
+++ b/bin/discover
@@ -56,6 +56,9 @@ do
     hidden)
       hidden=yes
       ;;
+    suffix=)
+      default_find_name_suffixes=
+      ;;
     suffix=*)
       _suffix=$(echo ${arg} | sed 's,suffix=,,')
       if validate_filename_part "${_suffix}" > /dev/null; then
@@ -113,10 +116,18 @@ done
 if [ -z "${find_name_suffixes}" ]; then
   find_name_suffixes=${default_find_name_suffixes}
 fi
-if [ -n "${find_name_prefixes}" ]; then
-  find_query="\( \( ${find_name_prefixes} \) ${find_pref_suff_joiner} \( ${find_name_suffixes} \) \)"
+if [ -n "${find_name_suffixes}" ]; then
+  if [ -n "${find_name_prefixes}" ]; then
+    find_query="\( \( ${find_name_prefixes} \) ${find_pref_suff_joiner} \( ${find_name_suffixes} \) \)"
+  else
+    find_query="\( ${find_name_suffixes} \)"
+  fi
 else
-  find_query="\( ${find_name_suffixes} \)"
+  if [ -n "${find_name_prefixes}" ]; then
+    find_query="\( ${find_name_prefixes} \)"
+  else
+    find_query=
+  fi
 fi
 
 if [ "${hidden}" == "no" ]; then


### PR DESCRIPTION
Prior to this change, default suffix filtering (to .yaml and .yml
filenames) was performed unless other `suffix*=` options were provided.
Disabling these default suffix filters would intuitively be performed
using `...?suffix=&...`, but this was vonsidered an invalid case.

This change adds explicit support for disabling the default suffix
filters using the `suffix=` option, and documents the behaviour (for
those who don't intuit it).