### PR TITLE
Optionally discover all prefixes/suffixes

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -140,6 +140,15 @@ jobs:
           expected: test://test/baz.txt
         run: sh -c "${TEST_SCRIPT}"
 
+      - name: Test single suffix-based protocol without suffix filtering behaviour
+        env:
+          path: discover://test?suffix=&suffix_protocol=.txt/test
+          expected: |-
+            test/bar.yml
+            test/foo.yaml
+            test://test/baz.txt
+        run: sh -c "${TEST_SCRIPT}"
+
       - name: Test single suffix-based protocol with other suffix behaviour
         env:
           path: discover://test?recursive&suffix_protocol=.enc/test&suffix=.txt
@@ -179,10 +188,28 @@ jobs:
           expected: test://test/bar.yml
         run: sh -c "${TEST_SCRIPT}"
 
+      - name: Test single prefix-based protocol without prefix filtering behaviour
+        # includes implicit suffix filter for .yaml/.yml files
+        env:
+          path: discover://test?prefix=&prefix_protocol=b/test
+          expected: |-
+            test/foo.yaml
+            test://test/bar.yml
+        run: sh -c "${TEST_SCRIPT}"
+
       - name: Test single prefix-based protocol without default suffix filtering behaviour
         env:
           path: discover://test?suffix=&prefix_protocol=b/test
           expected: |-
+            test://test/bar.yml
+            test://test/baz.txt
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test single prefix-based protocol without prefix or suffix filtering behaviour
+        env:
+          path: discover://test?suffix=&prefix_protocol=b/test
+          expected: |-
+            test/foo.yaml
             test://test/bar.yml
             test://test/baz.txt
         run: sh -c "${TEST_SCRIPT}"

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -207,7 +207,7 @@ jobs:
 
       - name: Test single prefix-based protocol without prefix or suffix filtering behaviour
         env:
-          path: discover://test?suffix=&prefix_protocol=b/test
+          path: discover://test?suffix=&prefix=&prefix_protocol=b/test
           expected: |-
             test/foo.yaml
             test://test/bar.yml

--- a/README.md
+++ b/README.md
@@ -89,9 +89,35 @@ values files are unexpectedly excluded (or included, when using the
 `union` option).
 
 However, these default suffix options will be removed if any other
-`suffix=...` and/or `suffix_protocol=.../...` options are specified.  As
-such, if you wish to disable suffix filtering entirely, the null-suffix
-option `suffix=` (e.g. `...?suffix=&...`) may be used.
+`suffix=...` and/or `suffix_protocol=.../...` options are specified.
+
+If you wish to disable suffix filtering entirely, the null-suffix
+option `suffix=` (e.g. `...?suffix=&...`) may be used; this will also
+disable any suffix filtering instituted by use of the `suffix_protocol`
+option.  The same is true of using the null `prefix=` to disable prefix
+filtering instituted by the use of `prefix_protocol`.
+
+Let us clarify with an example. With the following two files in a
+directory, the described queries will produce the given results:
+```
+foo.yaml bar.txt
+```
+```
+(default behaviour filtering to .yaml and .yml, no query string)
+foo.yaml
+```
+```
+?suffix_protocol=.txt/baz
+baz://bar.txt
+```
+```
+?suffix=
+foo.yaml,bar.txt
+```
+```
+?suffix=&suffix_protocol=.txt/baz
+foo.yaml,baz://bar.txt
+```
 
 ### Usecase: Encrypted values
 

--- a/bin/discover
+++ b/bin/discover
@@ -15,8 +15,11 @@ find_name_suffixes=
 values_files_sed_command=
 # Discard hidden files by default.
 hidden=no
-# Select only files with a valid yaml extension by default
+# Select only files with a valid yaml extension by default.
+# This will be set to null if suffix filtering is explicitly disabled.
 default_find_name_suffixes="-name '*.yaml' -o -name '*.yml'"
+# This will be set to null if prefix filtering is explicitly disabled.
+filter_by_prefixes=yes
 # By default, only select files that are direct children (not descendants) of the diven root.
 # All descendents may be discovered using the query argument "recursive".
 find_maxdepth_arg='-maxdepth 1'
@@ -58,6 +61,9 @@ do
       ;;
     suffix=)
       default_find_name_suffixes=
+      ;;
+    prefix=)
+      filter_by_prefixes=
       ;;
     suffix=*)
       _suffix=$(echo ${arg} | sed 's,suffix=,,')
@@ -113,7 +119,12 @@ done
 # CONSTRUCT FILE FILTERS/FORMATTERS
 
 # Construct find query
-if [ -z "${find_name_suffixes}" ]; then
+if [ -z "${filter_by_prefixes}" ]; then
+  find_name_prefixes=
+fi
+if [ -z "${default_find_name_suffixes}" ]; then
+  find_name_suffixes=
+elif [ -z "${find_name_suffixes}" ]; then
   find_name_suffixes=${default_find_name_suffixes}
 fi
 if [ -n "${find_name_suffixes}" ]; then


### PR DESCRIPTION
This increases the power of `suffix=&...` to preventing filtering by suffix, even if `suffix_protocol=...` is used to selectively assign protocols to some files.

This also adds corresponding special handling of the `prefix=&...` option to unilaterally prevent filtering by prefix.

Resolves: https://github.com/scalen/helm-discover/issues/5