### PR TITLE
Add universal protocol option

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -113,6 +113,25 @@ jobs:
             g: 7
         run: sh -c "${TEST_SCRIPT}"
 
+      - name: Test universal protocol behaviour
+        env:
+          path: discover://config?protocol=nest
+          expected: |-
+            nested:
+              a: 1
+              b: 2
+        run: sh -c "${TEST_SCRIPT}"
+
+      - name: Test universal protocol with recursive multi-suffix behaviour
+        env:
+          path: discover://config?protocol=nest&recursive&suffix=.txt&suffix=.yml
+          expected: |-
+            nested:
+              b: 2
+              c: 3
+              f: 6
+        run: sh -c "${TEST_SCRIPT}"
+
       - name: Test single suffix-based protocol behaviour
         env:
           path: discover://config?suffix_protocol=.txt/nest

--- a/README.md
+++ b/README.md
@@ -55,20 +55,21 @@ suffixes will be selected.
 `prefix=<prefix>`: Like `suffix=`, but for files named with the given
 prefix(es).
 
+`protocol=<protocol>`: Use the given protocol to process all files
+discovered.  This effectively expands the file names as follows:
+```
+path/to/values/filename -> <protocol>://path/to/values/filename
+```
+This is mostly to facilitate interactions with other plugins.
+
 `suffix_protocol=<suffix>/<protocol>`: Like `suffix=`, in that it selects
 files named with the given suffix(es); In addition, it uses the given
-protocol to process these specific files.  This effectively expands the
-file names as follows:
-```
-path/to/values/filename<suffix> -> <protocol>://path/to/values/filename<suffix>
-```
-This is mostly to facilitate interactions with other plugins.  For
+protocol to process only these specific files, as for `protocol=`.  For
 example, in order to discover values files with the suffix `.enc` that
-have been encrypted with
-[`helm-secrets`](https://github.com/jkroepke/helm-secrets), use the
-following query parameter:
+have been encrypted with [`helm-secrets`](https://github.com/jkroepke/helm-secrets),
+use the following query parameter:
 ```
-...?suffix_protocol=.enc/secrets
+...?suffix_protocol=.enc/secrets&...
 ```
 
 `prefix_protocol=<prefix>/<protocol>`: Like `suffix_protocol=`, but for files named with the given prefix(es).

--- a/bin/discover
+++ b/bin/discover
@@ -85,6 +85,10 @@ do
         find_name_prefixes="${find_name_prefixes}-name '${_prefix}*'"
       fi
       ;;
+    protocol=*)
+      _protocol=$(echo ${arg} | sed 's,protocol=\(.*\)$,\1://,')
+      values_files_sed_command="${values_files_sed_command};s,^,${_protocol},"
+      ;;
     suffix_protocol=*)
       _suffix=$(echo ${arg} | sed 's,suffix_protocol=,,;s,/.*$,,')
       _protocol=$(echo ${arg} | sed -n 's,^.*/\(..*\)$,\1://,p')


### PR DESCRIPTION
Prior to this change, protocols could only be applied to specific
prefixes/suffixes, making it difficult to apply them universally in the
context of complex option combinations.

This change adds a universal protocol option that applies the same
protocol to all files discovered according to the other options.